### PR TITLE
♻️  Refactoring file type discovery.

### DIFF
--- a/duplex/file_types.py
+++ b/duplex/file_types.py
@@ -11,32 +11,24 @@ from duplex import exceptions
 class FileHeaderHex(Enum):
     """Describes header hexadecimals for every supported file types."""
 
-    JFI = 'ffd8ffe0'
-    JPG = 'ffd8ffdb'
-    GIF = '47494638'
-    PNG = '89504e47'
-    TIF = '49492a00'
-    GZP = '1f8b0808'
-    GZT = '1f8b0800'
-    BZ2 = '425a6839'
-    ZIP = '504b0304'
-    LXZ = 'fd377a58'
-    JTI = 'ffd8ffe1'
-    JP3 = 'ffd8ffed'
+    JPG = 'ffd8ff'
+    GIF = '474946'
+    PNG = '89504e'
+    TIF = '49492a'
+    GZP = '1f8b08'
+    BZ2 = '425a68'
+    ZIP = '504b03'
+    LXZ = 'fd377a'
 
 
 class FileMimeTypes(Enum):
     """Describes the mime types associated with underlying files."""
 
-    JFI = 'image/jpeg'
     JPG = 'image/jpeg'
-    JP3 = 'image/jpeg'
     GIF = 'image/gif'
     PNG = 'image/png'
     TIF = 'image/tiff'
-    JTI = 'image/jpeg'
     GZP = 'application/gzip'
-    GZT = 'application/gzip'
     BZ2 = 'application/x-bzip2'
     ZIP = 'application/zip'
     LXZ = 'application/x-xz'
@@ -65,7 +57,7 @@ class FileType:
     @classmethod
     def header(cls, bytess):
         """
-        Return only the file header or the first four bytes.
+        Return only the file header or the first three bytes.
 
         Parameters
         ----------
@@ -77,7 +69,7 @@ class FileType:
         str:
             With the header hexadecimal representation
         """
-        return cls.to_hex(bytess[:4])
+        return cls.to_hex(bytess[:3])
 
     @classmethod
     def guess_file_type(cls, bytess, mimetype=False):

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -272,7 +272,7 @@ def test_infer_file_type_from_uri_no_mimetype():
     assert file_io.infer_file_type_from_uri(
         TEST_LOCAL,
         mimetype=False
-        ) == 'JFI'
+        ) == 'JPG'
 
 
 def test_infer_file_type_from_uri_unsupported():

--- a/tests/test_file_types.py
+++ b/tests/test_file_types.py
@@ -34,4 +34,4 @@ def test_guess_file_type_known_case():
     known case
     """
     with open(TEST_LOCAL, 'rb') as ffile:
-        assert FileType.guess_file_type(ffile.read()) == 'JFI'
+        assert FileType.guess_file_type(ffile.read()) == 'JPG'


### PR DESCRIPTION
**Resolves #17.**

* Only considering the first three bytes as file header, instead of the first four.
* Lean file discovery for `JPG` and `GZIP` formats