### PR TITLE
✨ Web interface port configuration and auto-discovery

### DIFF
--- a/tests/test_index/index.json
+++ b/tests/test_index/index.json
@@ -1,0 +1,1 @@
+{"import_images": true, "characteristic": "LIGHTWEIGHT_REGULAR_PRECISION"}

--- a/tests/test_pupyl.py
+++ b/tests/test_pupyl.py
@@ -1,5 +1,6 @@
 """Unit tests for main module pupyl."""
 import os
+import json
 from tempfile import gettempdir, TemporaryDirectory
 from pupyl import PupylImageSearch
 from embeddings.features import Characteristics
@@ -9,6 +10,7 @@ TEST_DATA_DIR = os.path.join(gettempdir(), 'pupyl_tests/')
 PUPYL = PupylImageSearch(data_dir=TEST_DATA_DIR)
 TEST_SCAN_DIR = os.path.abspath('tests/test_scan/test_csv.csv.gz')
 TEST_QUERY_IMAGE = 'https://static.flickr.com/210/500863916_bdd4b8cc5a.jpg'
+TEST_CONFIG_DIR = os.path.abspath('tests/test_index/')
 
 
 def test_index_no_config_file():
@@ -38,6 +40,24 @@ def test_index_creation_chosen_parameters():
         assert pupyl_test._import_images and \
             pupyl_test._characteristic == Characteristics.\
             LIGHTWEIGHT_REGULAR_PRECISION
+
+
+def test_index_config_file():
+    """Unit test for index creation, with config. file case."""
+    test_config_file = 'index.json'
+
+    with open(
+        os.path.join(TEST_CONFIG_DIR, test_config_file)
+    ) as config:
+        configurations = json.load(config)
+
+    test_pupyl = PupylImageSearch(TEST_CONFIG_DIR)
+
+    assert configurations['import_images'] == \
+        test_pupyl._import_images
+
+    assert configurations['characteristic'] == \
+        test_pupyl._characteristic.name
 
 
 def test_index():

--- a/web/interface.py
+++ b/web/interface.py
@@ -7,6 +7,7 @@ based on indexed images on database.
 import os
 from http.server import SimpleHTTPRequestHandler
 import socketserver
+import termcolor
 from urllib.parse import urlparse, parse_qs
 
 from pupyl import PupylImageSearch
@@ -16,8 +17,16 @@ STATIC_FOLDER = os.path.abspath(os.path.join('web', 'static'))
 TEMPLATE_FILE = os.path.join(STATIC_FOLDER, 'template.html')
 
 
-def serve(data_dir):
-    """Function to start the web server."""
+def serve(data_dir, port=8080):
+    """
+    Start the web server.
+
+    Parameters
+    ----------
+    port (optional)(default: 8080): int
+        Defines the network port which the web server
+        will start listening.
+    """
 
     pupyl_image_search = PupylImageSearch(data_dir)
 
@@ -149,5 +158,25 @@ def serve(data_dir):
 
             return image_tags
 
-    with socketserver.TCPServer(('', 8080), RequestHandler) as httpd:
-        httpd.serve_forever()
+    try:
+        with socketserver.TCPServer(('', port), RequestHandler) as httpd:
+            print(
+                termcolor.colored(
+                    f'Server listening on port {port}.',
+                    color='green',
+                    attrs=['bold']
+                )
+            )
+
+            httpd.serve_forever()
+
+    except OSError:
+        print(
+            termcolor.colored(
+                f'Port {port} already in use. Trying {port + 1}...',
+                color='red',
+                attrs=['bold']
+            )
+        )
+
+        serve(data_dir=data_dir, port=port + 1)


### PR DESCRIPTION
Resolves #29.

* Automatically retry if current `tcp` port trying to be opened by the web interface is already opened by another process.
* Try it recursively until find a free port.