### PR TITLE
🐛 Fixing indexation of unsupported files

### DIFF
--- a/pupyl/duplex/image.py
+++ b/pupyl/duplex/image.py
@@ -111,6 +111,21 @@ class ImageIO(FileIO):
         """
         return b64encode(cls.get_image(uri, as_tensor=False))
 
+    def scan_images(self, uri):
+        """
+        Scans a source looking for images.
+
+        Parameters
+        ----------
+        uri: str
+            Location where the source is stored.
+        """
+        for ffile in self.scan(uri):
+            file_bytes = self.get(ffile)
+
+            if self.is_image(file_bytes):
+                yield ffile
+
     @classmethod
     def get_image_bytes_to_base64(cls, image_bytes):
         """

--- a/pupyl/search.py
+++ b/pupyl/search.py
@@ -117,7 +117,9 @@ class PupylImageSearch:
                         rank,
                         uri_from_file
                     ): rank
-                    for rank, uri_from_file in enumerate(extractor.scan(uri))
+                    for rank, uri_from_file in enumerate(
+                        extractor.scan_images(uri)
+                    )
                 }
 
                 ranks = []

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -347,7 +347,7 @@ def test_export_group_by():
     test_files.add('group.jpg')
 
     with Index(test_vector_size, data_dir=TEST_INDEX_EXPORT) as index:
-        for _ in range(2):
+        for _ in range(8):
             index.append(numpy.random.normal(size=test_vector_size))
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_pupyl.py
+++ b/tests/test_pupyl.py
@@ -2,6 +2,9 @@
 import os
 import json
 from tempfile import gettempdir, TemporaryDirectory
+from unittest import TestCase
+from urllib.error import URLError
+
 from pupyl.search import PupylImageSearch
 from pupyl.embeddings.features import Characteristics
 
@@ -12,6 +15,15 @@ TEST_SCAN_DIR = os.path.abspath('tests/test_scan/test_csv.csv.gz')
 TEST_INVALID_URL = os.path.abspath('tests/test_scan/invalid.csv')
 TEST_QUERY_IMAGE = 'https://static.flickr.com/210/500863916_bdd4b8cc5a.jpg'
 TEST_CONFIG_DIR = os.path.abspath('tests/test_index/')
+
+
+class TestCases(TestCase):
+    """Unit tests over special cases."""
+
+    def test_index_invalid_url(self):
+        """Unit test for method index, invalid url case."""
+        with self.assertRaises(URLError):
+            PUPYL.index(TEST_INVALID_URL)
 
 
 def test_index_no_config_file():
@@ -68,13 +80,6 @@ def test_index():
     assert os.path.isdir(TEST_DATA_DIR) and \
         os.path.isfile(os.path.join(TEST_DATA_DIR, 'pupyl.index')) and \
         os.path.isfile(os.path.join(TEST_DATA_DIR, '0', '0.jpg'))
-
-
-def test_index_invalid_url():
-    """Unit test for method index, invalid url case."""
-    PUPYL.index(TEST_INVALID_URL)
-
-    assert True
 
 
 def test_pupyl_temp_data_dir():


### PR DESCRIPTION
**Resolves** #66.

* When scan() method was traversing a source, it was trying to index non-supported files;
* Now, a new method scan_images() was created to scan a directory, checking every file and only returning images.