### PR TITLE
⬇  Downgrading deps. due to issues on new tensorflow version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     url="https://github.com/policratus/pupyl",
     packages=setuptools.find_packages(),
     install_requires=[
-        'tensorflow==2.4.0',
+        'tensorflow==2.3.1',
         'annoy==1.17.0'
     ],
     classifiers=[


### PR DESCRIPTION
* Because of issue #[45744](https://github.com/tensorflow/tensorflow/issues/45744) of `tensorflow`, a downgrade from version 2.4.0 to 2.3.1 was necessary.