### PR TITLE
🐛 Fixing a memory leak on huge databases loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ clean:
 	@find . -name "*.log" | xargs rm -rf
 	@find . -name "*.egg-info" | xargs rm -rf
 	@find . -name "build" | xargs rm -rf
+	@find . -name ".mypy_cache" | xargs rm -rf
 	@-pkill -i 8888 || true
 
 flake8: clean

--- a/pupyl/indexer/facets.py
+++ b/pupyl/indexer/facets.py
@@ -77,7 +77,7 @@ class Index:
             try:
                 self.tree = AnnoyIndex(size, metric='angular')
 
-                self.tree.load(self._path)
+                self.tree.load(self._path, prefault=False)
 
                 self._is_new_index = False
             except OSError as os_error:
@@ -251,7 +251,7 @@ class Index:
         it, followed by reloading back the index.
         """
         self.tree.unload()
-        self.tree.load(self.path)
+        self.tree.load(self.path, prefault=False)
 
     def append(self, tensor, check_unique=False):
         """Inserts a new tensor at the end of the index.
@@ -347,7 +347,7 @@ class Index:
             If ``position`` is bigger than the index current size.
         """
         if self._is_new_index:
-            raise IndexNotBuildYet('Index file not build yet.')
+            raise IndexNotBuildYet('Index file not built yet.')
 
         if position > len(self):
             raise IndexError

--- a/pupyl/storage/database.py
+++ b/pupyl/storage/database.py
@@ -306,13 +306,13 @@ class ImageDatabase(ImageIO):
 
         self.save_image_metadata(index, uri)
 
-    def list_images(self, return_index=False, top=None):
-        """Returns all images in current database.
+    def list_images(self, return_ids=False, top=None):
+        """Returns images on current database.
 
         Parameters
         ----------
-        return_index: bool
-            If the method should also return the file index inside database.
+        return_ids: bool
+            If the method should also return the file ids inside database.
 
         top: int
             How many pictures from image database should be listed. Not setting
@@ -322,37 +322,33 @@ class ImageDatabase(ImageIO):
         Yields
         ------
         tuple or str:
-            If ``return_index=True``, a ``tuple`` with ``(int, str)``
+            If ``return_ids=True``, a ``tuple`` with ``(int, str)``
             representing respectively the index and the path inside the
-            database will be returned. Otherwise, if ``return_index=False``,
+            database will be returned. Otherwise, if ``return_ids=False``,
             just a ``str`` with the full path will return.
         """
         if top:
             counter = 0
 
         for root, _, files in os.walk(self._data_dir):
-
             for ffile in files:
+                if os.path.splitext(ffile)[-1] == '.jpg':
+                    ffile = os.path.join(root, ffile)
 
-                ffile = os.path.join(root, ffile)
+                    if top:
+                        counter += 1
 
-                with open(ffile, 'rb') as t_file:
-                    if self.is_image(t_file.read()):
+                        if counter > top:
+                            return
 
-                        if top:
-                            counter += 1
-
-                            if counter > top:
-                                return
-
-                        if return_index:
-                            yield int(
-                                os.path.splitext(
-                                    os.path.split(ffile)[1]
-                                )[0]
-                            ), ffile
-                        else:
-                            yield ffile
+                    if return_ids:
+                        yield int(
+                            os.path.splitext(
+                                os.path.split(ffile)[1]
+                            )[0]
+                        ), ffile
+                    else:
+                        yield ffile
 
     def load_image(self, index, as_tensor=False):
         """Returns the image data at a specified index.

--- a/pupyl/web/interface.py
+++ b/pupyl/web/interface.py
@@ -52,7 +52,7 @@ TEMPLATE = lzma.decompress(
 ).decode()
 
 
-def serve(data_dir=None, port=8080):
+def serve(data_dir=None, port=8080, **kwargs):
     """Starts the web server.
 
     Parameters
@@ -63,11 +63,19 @@ def serve(data_dir=None, port=8080):
 
     port: int
         Defines the network port which the web server will start listening.
+
+    extreme_mode: bool
+        Optional mode for general acceleration.
     """
     if not data_dir:
         data_dir = FileIO.pupyl_temp_data_dir()
 
-    pupyl_image_search = PupylImageSearch(data_dir)
+    if kwargs.get('extreme_mode') is None:
+        _extreme_mode = True
+    else:
+        _extreme_mode = kwargs['extreme_mode']
+
+    pupyl_image_search = PupylImageSearch(data_dir, extreme_mode=_extreme_mode)
 
     class RequestHandler(SimpleHTTPRequestHandler):
         """A web request handler."""
@@ -188,8 +196,8 @@ def serve(data_dir=None, port=8080):
                 return image_tags
 
             for index, image in pupyl_image_search.image_database.list_images(
-                    return_index=True,
-                    top=9
+                return_ids=True,
+                top=9
             ):
                 image_base64 = pupyl_image_search.image_database.\
                     get_image_base64(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -292,8 +292,8 @@ def test_list_images():
     assert expected_result == actual_result
 
 
-def test_list_images_return_index():
-    """Unit test for method list_images, return index case."""
+def test_list_images_return_ids():
+    """Unit test for method list_images, return ids case."""
     expected_path = abspath('tests/test_database/0/0.jpg')
     expected_index = 0
     expected_result = (expected_index, expected_path)
@@ -305,7 +305,7 @@ def test_list_images_return_index():
 
     actual_index_path = [
         *image_database.list_images(
-            return_index=True
+            return_ids=True
         )
     ][0]
 


### PR DESCRIPTION
* When opening large databases (say, 1M+ images), the web interface crashes due to a memory leak.