### PR TITLE
🐛 Handling local files (web interface) and file:// schemes.

### DIFF
--- a/pupyl/duplex/file_io.py
+++ b/pupyl/duplex/file_io.py
@@ -108,12 +108,31 @@ class FileIO(FileType):
             or an Enum describing that the format wasn't recognized.
         """
         if cls._infer_protocol(uri) is Protocols.FILE:
+            if request.urlparse(uri).scheme == 'file':
+                uri = cls._file_scheme_to_path(uri)
+
             return cls._get_local(uri)
 
         if cls._infer_protocol(uri) is Protocols.HTTP:
             return cls._get_url(uri)
 
         return Protocols.UNKNOWN
+
+    @staticmethod
+    def _file_scheme_to_path(uri):
+        """Converter from a file:// scheme to a path.
+
+        Parameters
+        ----------
+        uri: str
+            An URI to convert from `file://` scheme to a path
+
+        Example
+        -------
+        ``FileIO._file_scheme_to_path(file:///home/policratus/1073140.jpg)``
+        ``# Returns '/home/policratus/1073140.jpg'``
+        """
+        return uri[len('file://'):]
 
     @classmethod
     def get_metadata(cls, uri):
@@ -207,7 +226,7 @@ class FileIO(FileType):
         if request.urlparse(uri).scheme.startswith('http'):
             return Protocols.HTTP
 
-        if uri.startswith('file') or os.path.exists(uri):
+        if request.urlparse(uri).scheme == 'file' or os.path.exists(uri):
             return Protocols.FILE
 
         return Protocols.UNKNOWN

--- a/pupyl/web/interface.py
+++ b/pupyl/web/interface.py
@@ -103,9 +103,13 @@ def serve(data_dir=None, port=8080, **kwargs):
             image_tags = self.images(query_list)
 
             if query_list:
-                query_image = '<img class="img-thumbnail" ' + \
-                    f'src="{query_list[0]}">' + \
-                    '<figcaption class="figure-caption">' + \
+                query_image_base64 = pupyl_image_search.image_database.\
+                    get_image_base64(query_list[0])
+
+                query_image = '<img class="img-thumbnail" ' +\
+                    'src="data:image/jpg;base64, ' +\
+                    f'{query_image_base64.decode()}" alt="&#129535; Pupyl">' +\
+                    '<figcaption class="figure-caption">' +\
                     'Query image used in the search.</figcaption>'
 
             self.wfile.write(

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -26,6 +26,7 @@ TEST_URL = 'https://upload.wikimedia.org/wikipedia/commons/' + \
     'thumb/e/e4/Cheshm-Nazar.JPG/320px-Cheshm-Nazar.JPG'
 TEST_URL_NO_DATE = 'http://images.protopage.com/view/572714/' + \
     'axuvb8oxm7liskynxggfczfus.jpg'
+TEST_URL_FORBIDDEN = 'https://cutt.ly/hWtd8dN'
 TEST_CSV = abspath(TEST_SCAN_DIR + 'test_csv.csv')
 TEST_CSV_ZIP = abspath(TEST_SCAN_DIR + 'test_csv.csv.zip')
 TEST_CSV_GZ = abspath(TEST_SCAN_DIR + 'test_csv.csv.gz')
@@ -145,6 +146,11 @@ def test__get_url_unsuccessful():
         FileIO._get_url(TEST_UNKNOWN)
     except IOError:
         assert True
+
+
+def test__get_url_forbidden():
+    """Unit test for method _get_url, HTTP 403 case."""
+    assert isinstance(FileIO._get_url(TEST_URL_FORBIDDEN), bytes)
 
 
 def test_get_http():

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -170,7 +170,7 @@ def test__get_local_successful():
 
 def test_get_unknown():
     """
-        Unit test for get method, unknown case
+    Unit test for get method, unknown case
     """
     assert FileIO.get(TEST_UNKNOWN) is Protocols.UNKNOWN
 

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -545,7 +545,7 @@ def test_scan_compressed_tar_file_http():
 
 
 def test__file_scheme_to_path():
-    """Unit test for method _file_scheme_to_path"""
+    """Unit test for method _file_scheme_to_path."""
     test_uri = 'file:///path/to/a/test/file'
 
     assert FileIO._file_scheme_to_path(test_uri) == '/path/to/a/test/file'

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -170,9 +170,16 @@ def test__get_local_successful():
 
 def test_get_unknown():
     """
-    Unit test for get method, unknown case
+        Unit test for get method, unknown case
     """
     assert FileIO.get(TEST_UNKNOWN) is Protocols.UNKNOWN
+
+
+def test_get_file_scheme():
+    """Unit test for get method, file scheme case."""
+    test_file = f'file:///{TEST_LOCAL}'
+
+    assert isinstance(FileIO.get(test_file), bytes)
 
 
 def test_scan_directory():
@@ -535,3 +542,10 @@ def test_scan_compressed_tar_file_http():
 
     for ffile in file_io.scan_compressed_tar_file(test_uri, test_file_reader):
         assert os.path.exists(ffile)
+
+
+def test__file_scheme_to_path():
+    """Unit test for method _file_scheme_to_path"""
+    test_uri = 'file:///path/to/a/test/file'
+
+    assert FileIO._file_scheme_to_path(test_uri) == '/path/to/a/test/file'


### PR DESCRIPTION
**Resolves** #99.

* Fixing how `pupyl` web interface deals with local files using `file://` scheme;
* It's now possible to search on the web interface referencing local files.