### PR TITLE
📌 Updating dependencies coordinately

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setuptools.setup(
     url="https://github.com/policratus/pupyl",
     packages=setuptools.find_packages(),
     install_requires=[
-        'tensorflow==2.6.1',
-        'keras==2.6.0',
+        'tensorflow==2.7.0',
+        'keras==2.7.0',
         'annoy==1.17.0'
     ],
     classifiers=[


### PR DESCRIPTION
**Closes** #117 and #114.

* Pinning `tensorflow` and `keras` versions to `2.7.0`.