### PR TITLE
👷 Run CI tests on Ubuntu and macOS

### DIFF
--- a/.github/workflows/pupyl-ci.yml
+++ b/.github/workflows/pupyl-ci.yml
@@ -51,7 +51,10 @@ jobs:
         make static-check
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     name: test
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Since #169 has grown more complex than expected because of Windows issues, I think we should take a step back and test only on ubuntu and macOS.

Once we clear that, we can focus specifically on those windows related issues.